### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.4.2组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.vwfsag.fso</groupId>
 	<artifactId>WeChatConnector</artifactId>
@@ -12,7 +12,7 @@
 		<java.version>1.8</java.version>
 		<org.springframework.version>5.1.8.RELEASE</org.springframework.version>
 		<org.slf4j.version>1.7.21</org.slf4j.version>
-		<jackson.version>[2.9.9.2,)</jackson.version>
+		<jackson.version>2.9.10.8</jackson.version>
 	</properties>
 
 	<developers>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.4.2
漏洞编号：CVE-2020-8840
漏洞描述：FasterXML Jackson是美国FasterXML公司的一款适用于Java的数据处理工具。jackson-databind是其中的一个具有数据绑定功能的组件。
FasterXML jackson-databind 2.0.0版本至2.9.10.2版本中存在代码问题漏洞，该漏洞源于程序缺少xbean-reflect/JNDI黑名单类。攻击者可利用该漏洞执行代码。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2020-13183
影响范围：(∞, 2.6.7.4)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.vwfsag.fso:WeChatConnector@1.0.1-SNAPSHOT->io.jsonwebtoken:jjwt@0.6.0->com.fasterxml.jackson.core:jackson-databind@2.4.2
```
另外我运行这个项目时，IDE的安全插件提示还有76个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=peb63d